### PR TITLE
feat: CVE

### DIFF
--- a/mts-asn1-antlr/pom.xml
+++ b/mts-asn1-antlr/pom.xml
@@ -14,7 +14,6 @@
     <properties>
         <antlr4.visitor>true</antlr4.visitor>
         <antlr4.listener>false</antlr4.listener>
-        <antlr4.version>4.7.2</antlr4.version>
     </properties>
 
 
@@ -22,12 +21,10 @@
         <dependency>
             <groupId>org.antlr</groupId>
             <artifactId>antlr4-runtime</artifactId>
-            <version>${antlr4.version}</version>
         </dependency>
         <dependency>
             <groupId>org.antlr</groupId>
             <artifactId>antlr4</artifactId>
-            <version>${antlr4.version}</version>
         </dependency>
     </dependencies>
 

--- a/mts-asn1-core/pom.xml
+++ b/mts-asn1-core/pom.xml
@@ -16,7 +16,6 @@
         <dependency>
             <groupId>org.javatuples</groupId>
             <artifactId>javatuples</artifactId>
-            <version>1.2</version>
         </dependency>
         <dependency>
             <groupId>io.github.ericsson-mts</groupId>
@@ -26,7 +25,6 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.28</version>
         </dependency>
     </dependencies>
 </project>

--- a/mts-asn1-json/pom.xml
+++ b/mts-asn1-json/pom.xml
@@ -20,7 +20,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.10</version>
         </dependency>
     </dependencies>
 </project>

--- a/mts-asn1-maven-plugin/pom.xml
+++ b/mts-asn1-maven-plugin/pom.xml
@@ -31,22 +31,18 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.28</version>
         </dependency>
         <dependency>
             <groupId>com.squareup</groupId>
             <artifactId>javapoet</artifactId>
-            <version>1.11.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
-            <version>3.6.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
-            <version>3.6.0</version>
         </dependency>
     </dependencies>
 
@@ -55,7 +51,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
-                <version>3.6.0</version>
+                <version>${maven-plugin.version}</version>
             </plugin>
         </plugins>
     </build>

--- a/mts-asn1-per/pom.xml
+++ b/mts-asn1-per/pom.xml
@@ -22,20 +22,14 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.6</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.4.1</version>
-            <scope>test></scope>
         </dependency>
         <dependency>
             <groupId>net.javacrumbs.json-unit</groupId>
             <artifactId>json-unit</artifactId>
-            <version>2.8.0</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.github.ericsson-mts</groupId>
@@ -46,9 +40,7 @@
         <dependency>
             <groupId>xmlunit</groupId>
             <artifactId>xmlunit</artifactId>
-            <version>1.3</version>
-            <scope>test</scope>
-        </dependency>        
+        </dependency>
         <dependency>
             <groupId>io.github.ericsson-mts</groupId>
             <artifactId>mts-asn1-xml</artifactId>
@@ -58,14 +50,10 @@
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.13</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>1.7.28</version>
-            <scope>test</scope>
         </dependency>
     </dependencies>
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -53,11 +53,107 @@
     </modules>
 
     <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <junit.version>5.4.0</junit.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <!-- Library versions -->
+        <antlr4.version>4.7.2</antlr4.version>
+        <javatuples.version>1.2</javatuples.version>
+        <slf4j.version>2.0.6</slf4j.version>
+        <jackson-databind.version>2.14.2</jackson-databind.version>
+        <javapoet.version>1.11.1</javapoet.version>
+        <maven-plugin.version>3.6.0</maven-plugin.version>
+
+        <!-- Test library versions -->
+        <commons-codec.version>1.13</commons-codec.version>
+        <commons-io.version>2.6</commons-io.version>
+        <xmlunit.version>1.3</xmlunit.version>
+        <junit.version>5.4.0</junit.version>
+        <json-unit.version>2.8.0</json-unit.version>
+        <junit-jupiter.version>5.4.1</junit-jupiter.version>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.antlr</groupId>
+                <artifactId>antlr4-runtime</artifactId>
+                <version>${antlr4.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.antlr</groupId>
+                <artifactId>antlr4</artifactId>
+                <version>${antlr4.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.javatuples</groupId>
+                <artifactId>javatuples</artifactId>
+                <version>${javatuples.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>${slf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${jackson-databind.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.squareup</groupId>
+                <artifactId>javapoet</artifactId>
+                <version>${javapoet.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven</groupId>
+                <artifactId>maven-plugin-api</artifactId>
+                <version>${maven-plugin.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven.plugin-tools</groupId>
+                <artifactId>maven-plugin-annotations</artifactId>
+                <version>${maven-plugin.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-simple</artifactId>
+                <version>${slf4j.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>commons-io</groupId>
+                <artifactId>commons-io</artifactId>
+                <version>${commons-io.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>commons-codec</groupId>
+                <artifactId>commons-codec</artifactId>
+                <version>${commons-codec.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-engine</artifactId>
+                <version>${junit-jupiter.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>net.javacrumbs.json-unit</groupId>
+                <artifactId>json-unit</artifactId>
+                <version>${json-unit.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>xmlunit</groupId>
+                <artifactId>xmlunit</artifactId>
+                <version>${xmlunit.version}</version>
+                <scope>test</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <build>
         <plugins>


### PR DESCRIPTION
 - parent pom.xml : add dependencyManagement section to centralize versions of libraries to be used for submodules
 - bump version for slf4j library from 1.7.28 to 2.0.6
 - bump version for jackson libary from 2.9.10 to 2.14.2

Refs: MTSCUFBAT-3